### PR TITLE
DocComment: Parser and value object with operations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
   "require": {
     "phpunit/phpunit": "^6",
     "dompdf/dompdf": "^0.8",
-    "michelf/php-markdown": "^1.8"
+    "michelf/php-markdown": "^1.8",
+    "phpdocumentor/reflection-docblock": "~4"
   }
 }

--- a/lib/Pretzlaw/PHPUnit/DocGen/DocComment/Comment.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/DocComment/Comment.php
@@ -1,0 +1,141 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * Comment.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-09
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\DocComment;
+
+use Michelf\MarkdownExtra;
+use phpDocumentor\Reflection\DocBlock;
+use SimpleXMLElement;
+
+/**
+ * Comment
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-09
+ */
+class Comment
+{
+    /**
+     * @var DocBlock
+     */
+    private $docBlock;
+    private $html;
+    private $xml;
+
+    public function __construct(DocBlock $docBlock)
+    {
+        $this->docBlock = $docBlock;
+    }
+
+    public function docBlock()
+    {
+        return $this->docBlock;
+    }
+
+    /**
+     * @param string $xpath
+     * @param int|null $index
+     * @return SimpleXMLElement[]|SimpleXMLElement|bool
+     */
+    public function xpath(string $xpath, int $index = null)
+    {
+        $elements = $this->xml()->xpath($xpath);
+
+        if (null === $index) {
+            return $elements;
+        }
+
+        if (count($elements) < $index + 1) {
+            return false;
+        }
+
+        return $elements[$index];
+    }
+
+    private function xml(): SimpleXMLElement
+    {
+        if (null === $this->xml) {
+            $this->xml = simplexml_load_string('<html>' . $this->html() . '</html>');
+        }
+
+        return $this->xml;
+    }
+
+    public function html(): string
+    {
+        if (null === $this->html) {
+            $this->html = MarkdownExtra::defaultTransform($this->markdown());
+        }
+
+        return $this->html;
+    }
+
+    public function markdown(): string
+    {
+        $markdown = $this->docBlock()->getSummary();
+
+        if (false === strpos($markdown, "\n")) {
+            $markdown = '# ' . trim($markdown);
+        }
+
+        $markdown .= PHP_EOL . PHP_EOL;
+        $markdown .= $this->docBlock()->getDescription();
+
+        return trim($markdown);
+    }
+
+    public function execute($xpathOrIndex)
+    {
+        $index = 0;
+        if (is_int($xpathOrIndex)) {
+            $index = $xpathOrIndex;
+            $xpathOrIndex = '//pre/code';
+        }
+
+        $content = $this->xpath($xpathOrIndex, $index);
+
+        if (!$content || !$content instanceof SimpleXMLElement) {
+            throw new \RuntimeException('Code not found or empty: ' . $xpathOrIndex);
+        }
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'rmpup_dc_');
+
+        $isSaved = file_put_contents($tempFile, $content);
+
+        if (false === $isSaved) {
+            throw new \RuntimeException('Could not create tempfile for code: ' . $xpathOrIndex);
+        }
+
+        ob_start();
+        $return = require $tempFile;
+        $content = ob_get_clean();
+        unlink($tempFile);
+
+        if (1 !== $return) {
+            return $return;
+        }
+
+        return $content;
+    }
+}

--- a/lib/Pretzlaw/PHPUnit/DocGen/DocComment/Parser.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/DocComment/Parser.php
@@ -1,0 +1,84 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * DocQuery.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-09
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\DocComment;
+
+use phpDocumentor\Reflection\DocBlockFactory;
+use ReflectionClass;
+
+/**
+ * DocQuery
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-09
+ */
+trait Parser
+{
+    private $docBlockFactory;
+
+    public function classComment($className = null): Comment
+    {
+        if (null === $className) {
+            $className = get_class($this);
+        }
+
+        $reflection = new \ReflectionClass($className);
+
+        return new Comment($this->docBlockFactory()->create((string)$reflection->getDocComment()));
+    }
+
+    public function comment(): Comment
+    {
+        return $this->methodComment(get_class($this), $this->getName());
+    }
+
+    public function methodComment($classOrMethodName, $method = null): Comment
+    {
+        if (null === $method) {
+            $parts = explode('::', $classOrMethodName);
+
+            $classOrMethodName = get_class($this);
+            $method = array_pop($parts);
+
+            if ($parts) {
+                $classOrMethodName = array_pop($parts);
+            }
+        }
+
+        $reflection = new ReflectionClass($classOrMethodName);
+        $method = $reflection->getMethod($method);
+
+        return new Comment($this->docBlockFactory()->create((string)$method->getDocComment()));
+    }
+
+
+    private function docBlockFactory(): DocBlockFactory
+    {
+        if (null === $this->docBlockFactory) {
+            $this->docBlockFactory = DocBlockFactory::createInstance();
+        }
+
+        return $this->docBlockFactory;
+    }
+}

--- a/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/ExecuteCodeTest.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/ExecuteCodeTest.php
@@ -1,0 +1,62 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ExecuteCodeTest.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-10
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\Test\DocComment;
+
+use Pretzlaw\PHPUnit\DocGen\Test\TestCase;
+
+/**
+ * ExecuteCodeTest
+ *
+ * This is some simple code returning an `integer`:
+ *
+ * ```php
+ * <?php
+ *
+ * return 1337;
+ * ```
+ *
+ * But this is missing an opener:
+ *
+ * ```php
+ * return ['no', 'opener'];
+ * ```
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-10
+ */
+class ExecuteCodeTest extends TestCase
+{
+    public function testExecuteCodeWithOpener()
+    {
+        $value = $this->classComment()->execute('//pre/code', 0);
+
+        static::assertSame(1337, $value);
+    }
+
+    public function testCodeWithoutOpener()
+    {
+        static::assertSame('return [\'no\', \'opener\'];', trim($this->classComment()->execute(1)));
+    }
+}

--- a/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/ToHtmlTest.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/ToHtmlTest.php
@@ -1,0 +1,59 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ToHtmlTest.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-09
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\Test\DocComment;
+
+use Pretzlaw\PHPUnit\DocGen\Parser;
+use Pretzlaw\PHPUnit\DocGen\Test\TestCase;
+
+/**
+ * Html
+ *
+ * This part should be turned into markdown.
+ *
+ * It contains an enumeration:
+ *
+ * 1. One
+ * 2. Two
+ * 3. Four
+ *
+ * And an itemization:
+ *
+ * * Itemi
+ * * zation
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-09
+ */
+class ToHtmlTest extends TestCase
+{
+    public function testHeading()
+    {
+        $html = $this->classComment()->html();
+
+        static::assertContains('<h1>Html</h1>', $html);
+        static::assertContains('<li>One</li>', $html);
+        static::assertContains('<li>Itemi</li>', $html);
+    }
+}

--- a/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/ToMarkdownTest.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/ToMarkdownTest.php
@@ -1,0 +1,98 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ToHtmlTest.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-09
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\Test\DocComment;
+
+use Pretzlaw\PHPUnit\DocGen\Test\TestCase;
+
+/**
+ * Create markdown
+ *
+ * This part should be turned into markdown.
+ *
+ * It contains an enumeration:
+ *
+ * 1. One
+ * 2. Two
+ * 3. Four
+ *
+ * And an itemization:
+ *
+ * * Itemi
+ * * zation
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-09
+ */
+class ToMarkdownTest extends TestCase
+{
+    private static function assertClassComment(string $markdown)
+    {
+        static::assertStringStartsWith('# Create markdown', $markdown);
+        static::assertStringEndsWith('* zation', $markdown);
+    }
+
+    public function testCreateMarkdownFromClass()
+    {
+        static::assertClassComment($this->classComment(__CLASS__)->markdown());
+    }
+
+    public function testCreatesMarkdownWithoutExplicitClassName()
+    {
+        static::assertClassComment($this->classComment()->markdown());
+    }
+
+    /**
+     * This comment has no header
+     * and directly starts with content.
+     */
+    public function testCreatesMarkdownFromMethodName()
+    {
+        $markdown = $this->methodComment(__METHOD__)->markdown();
+
+        static::assertStringStartsWith('This comment has no header', $markdown);
+        static::assertStringEndsWith('with content.', $markdown);
+    }
+
+    /**
+     * Explicit
+     *
+     * And some body here.
+     */
+    public function testCreatesMarkdownFromExplizitMethodName()
+    {
+        $markdown = $this->methodComment(__CLASS__, __FUNCTION__)->markdown();
+
+        static::assertStringStartsWith('# Explicit', $markdown);
+        static::assertStringEndsWith('body here.', $markdown);
+    }
+
+    /**
+     * Just heading
+     */
+    public function testCreatesMarkdownFromComment()
+    {
+        static::assertEquals('# Just heading', $this->comment()->markdown());
+    }
+}

--- a/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/XPathTest.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/Test/DocComment/XPathTest.php
@@ -1,0 +1,92 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * XPathTest.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-09
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\Test\DocComment;
+
+use Pretzlaw\PHPUnit\DocGen\DocComment\Comment;
+use Pretzlaw\PHPUnit\DocGen\Test\TestCase;
+
+/**
+ * XPathTest
+ *
+ * First enum:
+ *
+ * * Some
+ * * bullets
+ *
+ * Second enum:
+ *
+ * * Another one
+ * * Bites
+ * * The Dust
+ *
+ * Numbers:
+ *
+ * 1. Uno
+ * 2. Dos
+ * 3. Drei
+ * 4. Four
+ *
+ * Goodbye
+ *
+ * > Okay.
+ *
+ * Exchange 61 with 16 because 15 is Magna Charta.
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-09
+ */
+class XPathTest extends TestCase
+{
+    /**
+     * @var Comment
+     */
+    private $comment;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->comment = $this->classComment();
+    }
+
+    public function testFetchMultiple()
+    {
+        $elements = $this->comment->xpath('//ul');
+
+        static::assertCount(2, $elements);
+    }
+
+    public function testFetchSingle()
+    {
+        $element = $this->comment->xpath('//ul', 1);
+
+        static::assertCount(3, $element->children());
+    }
+
+    public function testFetchInvalid()
+    {
+        static::assertFalse($this->comment->xpath('//ul', 5));
+    }
+}

--- a/lib/Pretzlaw/PHPUnit/DocGen/Test/TestCase.php
+++ b/lib/Pretzlaw/PHPUnit/DocGen/Test/TestCase.php
@@ -1,0 +1,38 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * TestCase.php
+ *
+ * LICENSE: This source file is created by the company around Mike Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ *
+ * @package    phpunit-docgen
+ * @copyright  2019 Mike Pretzlaw
+ * @license    https://mike-pretzlaw.de/license-generic.txt
+ * @link       https://project.mike-pretzlaw.de/phpunit-docgen
+ * @since      2019-06-09
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\PHPUnit\DocGen\Test;
+
+use Pretzlaw\PHPUnit\DocGen\DocComment\Parser;
+
+/**
+ * TestCase
+ *
+ * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @since      2019-06-09
+ */
+abstract class TestCase extends \PHPUnit\Framework\TestCase
+{
+    use Parser;
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
 >
     <testsuites>
         <testsuite name="default">
-            <directory>lib/Test</directory>
+            <directory>lib/Pretzlaw/PHPUnit/DocGen/Test</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
We regularly need to read the doc comment
and apply actions on it.
This needed to be implemened in every single project over
and over again.
Now we bring basic operations in like XPath
and executing PHP that is written in code-blocks.